### PR TITLE
Fix build with Boost.Serialization 1.58

### DIFF
--- a/src/Data/Serialization.h
+++ b/src/Data/Serialization.h
@@ -32,6 +32,11 @@
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/serialization/list.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 105800
+#include <boost/serialization/collections_save_imp.hpp>
+#include <boost/serialization/collections_load_imp.hpp>
+#endif
 #include <exception>
 #include "Matrix.h"
 


### PR DESCRIPTION
Include the necessary headers for implementation details such as load_collection, archive_input_seq and no_reserve_imp.

Fixes #8.