### PR TITLE
add checkboxes for libwfa for CIS, ADC, EOM-CC

### DIFF
--- a/doc/build_linux
+++ b/doc/build_linux
@@ -17,7 +17,7 @@ apt-get install libopenbabel-dev
 git clone https://github.com/nutjunkie/IQmol.git
 
 cd IQmol/src
-qmake IQmol
+qmake IQmol.pro
 make
 
 

--- a/src/Qui/AdcTab.ui
+++ b/src/Qui/AdcTab.ui
@@ -118,6 +118,13 @@
        </property>
       </widget>
      </item>
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="state_analysis">
+       <property name="text">
+        <string>State analysis (libwfa)</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/Qui/CisTab.ui
+++ b/src/Qui/CisTab.ui
@@ -70,6 +70,13 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="2" colspan="2">
+      <widget class="QCheckBox" name="state_analysis">
+       <property name="text">
+        <string>State analysis (libwfa)</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="4">
       <widget class="QCheckBox" name="spin_flip_xcis">
        <property name="text">

--- a/src/Qui/EomTab.ui
+++ b/src/Qui/EomTab.ui
@@ -122,7 +122,13 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="2">
+      <widget class="QCheckBox" name="state_analysis">
+       <property name="text">
+        <string>State analysis (libwfa)</string>
+       </property>
+      </widget>
+     </item>     <item row="2" column="0">
       <widget class="QLabel" name="label_cc_state_to_opt">
        <property name="text">
         <string>State to optimize</string>


### PR DESCRIPTION
Hello, I added some checkboxes for our libwfa functionality (`state_analysis` keyword). Is it enough to just add the appropriate items the `.ui` files?

Is it ok to put this into the main panel or should I only put it into "Advanced"? I think this is a functionality that quite a few people are using.

Cheers
-Felix