### PR TITLE
conda / brew build instructions for mac osx

### DIFF
--- a/doc/build_osx
+++ b/doc/build_osx
@@ -32,15 +32,15 @@ libraries.  The compilation of the code itself is relatively straightforward.
         ./Configure darwin64-x86_64-cc
         make
 
-   - Static libraries appear in top directory and may need to be moved to the lib
-     subdirectory for the libssh2 compilation.
+   - Static libraries (libssl.a & libcrypto.a) appear in top directory and may need to be moved to the lib
+     subdirectory (which may need to be created) for the libssh2 compilation.
 
 
  o LibSSH2:
-   - Download: http://www.libssh2.org  (version 1.8.0 tested)
+   - Download: http://www.libssh2.org  (version 1.9.0 tested)
    - Compile (making sure the correct path for libssl is specified): 
 
-        ./configure --with-openssl --with-libssl-prefix=/path/to/openssl-1.0.1p --with-libz
+        ./configure --with-crypto=openssl --with-libssl-prefix=/path/to/openssl-1.0.1q --with-libz
         make
 
    - Shared and static libraries located in src/.libs
@@ -50,31 +50,19 @@ cmake -DOPENSSL_ROOT_DIR=$DEV/openssl-1.1.1f/ -DOPENSSL_INCLUDE_DIR=$DEV/openssl
 
 
  o Boost:
-   - Download: http://sourceforge.net/projects/boost/files/boost/1.56.0/
-     Later versions of boost seem to have removed the load_collection function which
-     is part of the serialization routines.
-   - Compile: needs the -stdlib=libstdc++ setting to be compatible with Qt.
-     Further details at: http://stackoverflow.com/questions/20108407/
+   - Download: http://sourceforge.net/projects/boost/files/boost/1.76.0/
 
-        ./bootstrap.sh --prefix= toolset=clang
-        ./b2 toolset=clang --without-mpi cxxflags="-arch x86_64 -fvisibility=hidden \
-             -fvisibility-inlines-hidden -stdlib=libstdc++ -ftemplate-depth=512" \
-             linkflags="-stdlib=libstdc++" stage
+        ./bootstrap.sh --prefix= -with-toolset=clang
+        ./b2 
 
-   - Static libraries are in stage/lib.  If they do not appear you may need to
-     add "link=static runtime-link=static" to the b2 arguments
+   - Static libraries are in stage/lib.
 
 
  o OpenBabel:
-   - Download: http://openbabel.org/wiki/Get_Open_Babel (2.4.1)
-     Use the installer which puts things in the following locations:
-     Headers: /usr/local/include/openbabel-2.0
-     PlugIns: /usr/local/lib/openbable/2.4.1
-     Libs:    /usr/local/lib
+   - Download: https://sourceforge.net/projects/openbabel/files/openbabel/ (2.4.1)
+   - Source can be downloaded and compiled with (in the build directory):
 
-   - Alternatively, the source can be downloaded and compiled with (in the build directory):
-
-        cmake -DBUILD_SHARED=OFF -DWITH_STATIC_INCHI=ON -DWITH_STATIC_LIBXML=ON ..
+        cmake -DBUILD_SHARED=OFF -DWITH_STATIC_INCHI=ON -DWITH_STATIC_LIBXML=ON -DLIBXML2_LIBRARIES=/path/to/libxml2/2.9.12/lib/ -DLIBXML2_INCLUDE_DIR=/path/to/libxml2/2.9.12/include -DZLIB_LIBRARY=/path/to/zlib/1.2.11/lib/ -DZLIB_INCLUDE_DIR=/path/to/zlib/1.2.11/include/ ..
         make
 
 	 The static libopenbabel.a will be in the build/src directory. This 
@@ -85,13 +73,18 @@ cmake -DOPENSSL_ROOT_DIR=$DEV/openssl-1.1.1f/ -DOPENSSL_INCLUDE_DIR=$DEV/openssl
 Compilation
 ~~~~~~~~~~~
 
- o Compile the SymMol object file in src/Main
+ o Compile the SymMol object file in src/Main and copy symmol.o to ../../build
       gfortran -c symmol.f90
 
  o Edit the common.pri file to reflect the locations of the various libraries
    required.  I keep all these in a common directory set in the $DEV environment
    variable.
 
- o Compile the remaining IQmol source
+ o Compile the remaining IQmol source. The application will be built in
+   IQmol.app/Contents/MacOS/
       qmake IQmol.pro
       make
+
+ o If the previous step is successful, copy share/ to IQmol.app/Contents. This
+   enables the use of shaders, molecule fragments, and the QUI interface.
+

--- a/doc/build_osx_updated
+++ b/doc/build_osx_updated
@@ -95,9 +95,3 @@ Possible Issues
    /path/to/conda/env/share/openbabel/2.4.1. This allows the user to use 
    the "Geometry Optimisation" function of IQmol.
 
- o If there are compile issues involving yaml-cpp/node/node.h, add the
-   following include statment to Yaml/yaml-cpp/node/node.h. This issue
-   should be fixed in a future PR.
-      #include <string>
-
-

--- a/doc/build_osx_updated
+++ b/doc/build_osx_updated
@@ -1,0 +1,103 @@
+                     ==============================================
+                      Building IQmol with Conda & Homebrew on OS X
+                     ==============================================
+
+
+Libraries
+~~~~~~~~~
+
+ o You will need XCode > 5.0 installed in order to install the Qt libraries.
+   To get the command line tools installed you need to run:
+     xcode-select --install
+
+ o Cmake will be required to compile some of the libraries, the installer can 
+   be obtained from http://www.cmake.org/download/
+
+ o You may wish to perform the following commands inside a conda environment.
+
+    conda install -c conda-forge openbabel=2.4
+    conda install qt=5.9.7
+    conda install libssh2
+
+    brew install boost
+    brew install gfortran
+    brew install openssl@1.1
+
+ o Update the mac.pri file to include the required INLCUDEPATH and LIBS
+   environment variables for Boost, openssl, libssh2, openbabel, and
+   gfortran. Supposing the above commands were run inside a conda
+   environment called 'iqmol-dev', the following mac.pri could be used
+   as an example. Your mileage may vary.
+
+    CONFIG += DEPLOY
+
+    contains(CONFIG, DEPLOY) {
+       CONFIG += release
+
+       # Boost
+       BOOST        = /usr/local/Cellar/boost/1.76.0/
+       INCLUDEPATH += $${BOOST}/include
+       LIBS        += $${BOOST}/lib/libboost_iostreams.a
+       LIBS        += $${BOOST}/lib/libboost_serialization.a
+       LIBS        += $${BOOST}/lib/libboost_exception.a
+
+       # libssl/libcrypto
+       INCLUDEPATH += /usr/local/Cellar/openssl\@1.1/1.1.1k/include/
+       LIBS        += /usr/local/Cellar/openssl@1.1/1.1.1k/lib/libssl.a
+       LIBS        += /usr/local/Cellar/openssl@1.1/1.1.1k/lib/libcrypto.a
+
+       # SSH2
+       INCLUDEPATH += /opt/anaconda3/envs/iqmol-dev/include
+       LIBS        += /opt/anaconda3/envs/iqmol-dev/lib/libssh2.dylib
+
+       # OpenBabel
+       OPENBABEL    = /opt/anaconda3/envs/iqmol-dev/include/openbabel-2.0/
+       INCLUDEPATH += /opt/anaconda3/envs/iqmol-dev/include/openbabel-2.0/
+       LIBS        += /opt/anaconda3/envs/iqmol-dev/lib/libopenbabel.dylib
+       LIBS        += /opt/anaconda3/envs/iqmol-dev/lib/libopenbabel.5.dylib
+       LIBS        += /opt/anaconda3/envs/iqmol-dev/lib/libinchi.dylib
+
+       # gfortran
+       LIBS        += /usr/local/Cellar/gcc/11.2.0/lib/gcc/11/libgfortran.a
+       LIBS        += /usr/local/Cellar/gcc/11.2.0/lib/gcc/11/libquadmath.a
+       LIBS        += -L/usr/local/Cellar/gcc/11.2.0/lib/gcc/11/ -lgcc_ext.10.5
+
+       # Misc
+       LIBS        += -L/usr/X11/lib  
+       LIBS        += -framework GLUT
+       LIBS        += -L/usr/lib -lz -lxml2
+
+       QMAKE_LFLAGS   += -Wl,-no_compact_unwind -stdlib=libc++ 
+       QMAKE_RPATHDIR += @executable_path/../Frameworks
+    }
+
+
+Compilation
+~~~~~~~~~~~
+
+ o Compile the SymMol object file in src/Main and copy symmol.o to ../../build
+      gfortran -c symmol.f90
+
+ o Compile the remaining IQmol source. The application will be built in 
+   IQmol.app/Contents/MacOS/
+      qmake IQmol.pro
+      make
+
+ o If the previous step is successful, copy share/ to IQmol.app/Contents. This
+   enables the use of shaders, molecule fragments, and the QUI interface.
+
+
+Possible Issues
+~~~~~~~~~~~~~~~
+
+ o It may be necessary to define BABEL_LIBDIR and BABEL_DATADIR 
+   as environment variables to /path/to/conda/env/lib/openbabel/2.4.1 and 
+   /path/to/conda/env/share/openbabel/2.4.1. This allows the user to use 
+   the "Geometry Optimisation" function of IQmol.
+
+ o If there are compile issues involving yaml-cpp/node/node.h, add the
+   following include statment to Yaml/yaml-cpp/node/node.h. This issue
+   should be fixed in a future PR.
+      #include <string>
+
+

--- a/src/Yaml/yaml-cpp/node/node.h
+++ b/src/Yaml/yaml-cpp/node/node.h
@@ -12,6 +12,7 @@
 #include "yaml-cpp/node/detail/iterator_fwd.h"
 #include "yaml-cpp/node/detail/bool_type.h"
 #include <stdexcept>
+#include <string>
 
 namespace YAML
 {


### PR DESCRIPTION
Updated build instructions for building IQmol from source using conda and brew. This removes the need to download and compile libraries manually. Updated instructions for compiling newer and working versions of required libraries in build_osx

Updated node.h to prevent compile issue (related to newer compiler version) when compiling according to build_osx_updated. 

@hmacdope did most of the hard work getting it all to work.