### PR TITLE
Port IQmol to OpenBabel 3

### DIFF
--- a/src/Configurator/IsotopesConfigurator.C
+++ b/src/Configurator/IsotopesConfigurator.C
@@ -23,6 +23,7 @@
 #include "IsotopesConfigurator.h"
 #include "IsotopesLayer.h"
 #include "openbabel/data.h"
+#include "openbabel/elements.h"
 #include "AtomLayer.h"
 #include <QComboBox>
 #include <QSpinBox>
@@ -75,14 +76,13 @@ void Isotopes::loadTable(QList<Layer::Atom*> const& atoms)
    QTableWidgetItem* index;
    QComboBox* combo;
 
-   OpenBabel::OBElementTable pt;
    unsigned n(atomicNumbers.size());
    table->setRowCount(n);
 
    for (unsigned i = 0; i < n; ++i) {
        unsigned Z(atomicNumbers[i]);
        combo = new QComboBox(table);
-       name  = new QTableWidgetItem(QString::fromStdString(pt.GetName(Z)));
+       name  = new QTableWidgetItem(QString::fromStdString(OpenBabel::OBElements::GetName(Z)));
        index = new QTableWidgetItem(indices[Z]);
        table->setItem(      i, 0, name);
        table->setCellWidget(i, 1, combo);
@@ -94,12 +94,8 @@ void Isotopes::loadTable(QList<Layer::Atom*> const& atoms)
 
 void Isotopes::loadMasses(unsigned Z, QComboBox* combo)
 {
-   OpenBabel::OBElementTable pt;
-   OpenBabel::OBIsotopeTable it;
-
-
    QList<unsigned> isotopes;
-   QString symbol(pt.GetSymbol(Z));
+   QString symbol(OpenBabel::OBElements::GetSymbol(Z));
 
    // The isotopes are ordered by abundance
    switch(Z) {
@@ -150,12 +146,12 @@ void Isotopes::loadMasses(unsigned Z, QComboBox* combo)
    }
 
    combo->clear();
-   double m(pt.GetMass(Z));
+   double m(OpenBabel::OBElements::GetMass(Z));
    combo->addItem(symbol + "(std)", m);
 
    for (int i = 0; i < isotopes.size(); ++i) {
        QString label(symbol + "(" + QString::number(isotopes[i]) + ")");
-       double m(it.GetExactMass(Z,isotopes[i]));
+       double m(OpenBabel::OBElements::GetExactMass(Z,isotopes[i]));
        combo->addItem(label, m);
    }
 }

--- a/src/Configurator/SurfaceConfigurator.C
+++ b/src/Configurator/SurfaceConfigurator.C
@@ -24,7 +24,8 @@
 #include "SurfaceConfigurator.h"
 #include "SurfaceLayer.h"
 #include "MoleculeLayer.h"
-#include <openbabel/mol.h>  // for etab
+#include <openbabel/mol.h>
+#include <openbabel/elements.h>
 #include <QColorDialog>
 
 
@@ -228,7 +229,8 @@ ColorGradient::ColorList Surface::atomColorGradient(unsigned const maxAtomicNumb
    ColorGradient::ColorList atomColors;
    QColor color;
    for (unsigned int Z = 1; Z <= maxAtomicNumber; ++Z) {
-       std::vector<double> rgb(OpenBabel::etab.GetRGB(Z));
+       std::vector<double> rgb(3);
+       OpenBabel::OBElements::GetRGB(Z,&rgb[0],&rgb[1],&rgb[2]);
        color.setRgbF(rgb[0],rgb[1],rgb[2],1.0);
        atomColors.append(color);
    }

--- a/src/Data/Atom.C
+++ b/src/Data/Atom.C
@@ -23,6 +23,7 @@
 #include "Atom.h"
 #include "AtomicProperty.h"
 #include <openbabel/mol.h>
+#include <openbabel/elements.h>
 #include <QDebug>
 
 
@@ -34,7 +35,7 @@ template<> const Type::ID AtomList::TypeID = Type::AtomList;
 
 unsigned Atom::atomicNumber(QString const& symbol) 
 {
-   unsigned z(OpenBabel::etab.GetAtomicNum(symbol.toLatin1().data()));
+   unsigned z(OpenBabel::OBElements::GetAtomicNum(symbol.toLatin1().data()));
    return z;
 }
 

--- a/src/Data/AtomicProperty.C
+++ b/src/Data/AtomicProperty.C
@@ -22,6 +22,7 @@
 
 #include "AtomicProperty.h"
 #include <openbabel/mol.h>
+#include <openbabel/elements.h>
 #include <vector>
 #include <QDebug>
 
@@ -32,7 +33,7 @@ namespace Data {
 //  ---------- AtomicSymbol ----------
 void AtomicSymbol::setDefault(int const Z)
 {
-   if (Z > 0) m_symbol = QString(OpenBabel::etab.GetSymbol(Z));
+   if (Z > 0) m_symbol = QString(OpenBabel::OBElements::GetSymbol(Z));
 }
 
 
@@ -54,7 +55,7 @@ void ScalarProperty::dump() const
 //  ---------- Mass ----------
 void Mass::setDefault(int const Z)
 {
-   if (Z > 0) m_value = OpenBabel::etab.GetMass(Z);
+   if (Z > 0) m_value = OpenBabel::OBElements::GetMass(Z);
 }
 
 
@@ -62,7 +63,7 @@ void Mass::setDefault(int const Z)
 //  ---------- VdwRadius ----------
 void VdwRadius::setDefault(int const Z)
 {
-   if (Z > 0) m_value = OpenBabel::etab.GetVdwRad(Z);
+   if (Z > 0) m_value = OpenBabel::OBElements::GetVdwRad(Z);
 }
 
 
@@ -71,10 +72,7 @@ void VdwRadius::setDefault(int const Z)
 void AtomColor::setDefault(int const Z)
 {
    if (Z > 0) {
-      std::vector<double> rgb(OpenBabel::etab.GetRGB(Z));
-      m_color[0] = rgb[0];
-      m_color[1] = rgb[1];
-      m_color[2] = rgb[2];
+      OpenBabel::OBElements::GetRGB(Z, &m_color[0], &m_color[1], &m_color[2]);
       m_color[3] = 1.0;
    }
 }

--- a/src/Data/EfpFragment.C
+++ b/src/Data/EfpFragment.C
@@ -25,6 +25,7 @@
 #include "EulerAngles.h"
 #include "Align.h"
 #include "openbabel/mol.h"
+#include "openbabel/elements.h"
 #include <QDebug>
 
 
@@ -58,7 +59,7 @@ bool EfpFragment::align(QList<Vec> const& coordinates)
    
    QList<double> weights;
    for (unsigned i = 0; i < geometry.nAtoms(); ++i) {
-       weights.append(OpenBabel::etab.GetMass(geometry.atomicNumber(i))); 
+       weights.append(OpenBabel::OBElements::GetMass(geometry.atomicNumber(i))); 
    }
 
    Util::Align align(geometry.coordinates(), coordinates, weights);

--- a/src/Data/Geometry.C
+++ b/src/Data/Geometry.C
@@ -26,6 +26,8 @@
 #include "QsLog.h"
 #include <QDebug>
 #include "openbabel/mol.h"
+#include "openbabel/atom.h"
+#include "openbabel/obiter.h"
 
 
 namespace IQmol {
@@ -258,7 +260,7 @@ return;
     OpenBabel::OBMol obMol;
 
     obMol.BeginModify();
-    obMol.UnsetPartialChargesPerceived();
+    obMol.SetPartialChargesPerceived(false);
     for (int i = 0; i < m_atoms.size(); ++i) {
         obAtom = obMol.NewAtom();
         obAtom->SetAtomicNum(m_atoms[i]->atomicNumber());

--- a/src/Layer/AtomLayer.C
+++ b/src/Layer/AtomLayer.C
@@ -27,6 +27,7 @@
 #include "GLShape.h"
 #include <openbabel/mol.h>
 #include <openbabel/data.h>
+#include <openbabel/elements.h>
 #include <QColor>
 #include <QMenu>
 #include <vector>
@@ -147,20 +148,21 @@ void Atom::updateHybridization()
 
 void Atom::resetMass()
 {
-   m_mass = OpenBabel::etab.GetMass(m_atomicNumber);
+   m_mass = OpenBabel::OBElements::GetMass(m_atomicNumber);
 }
 
 
 void Atom::setAtomicNumber(unsigned int const Z) 
 {
    m_atomicNumber = Z;
-   m_vdwRadius = OpenBabel::etab.GetVdwRad(Z);
-   m_mass      = OpenBabel::etab.GetMass(Z);
-   m_symbol    = QString(OpenBabel::etab.GetSymbol(Z));
-   m_valency   = OpenBabel::etab.GetMaxBonds(Z);
+   m_vdwRadius = OpenBabel::OBElements::GetVdwRad(Z);
+   m_mass      = OpenBabel::OBElements::GetMass(Z);
+   m_symbol    = QString(OpenBabel::OBElements::GetSymbol(Z));
+   m_valency   = OpenBabel::OBElements::GetMaxBonds(Z);
    setText(m_symbol);
 
-   std::vector<double> rgb(OpenBabel::etab.GetRGB(Z));
+   std::vector<double> rgb(3);
+   OpenBabel::OBElements::GetRGB(Z,&rgb[0],&rgb[1],&rgb[2]);
    m_color[0] = rgb[0];
    m_color[1] = rgb[1];
    m_color[2] = rgb[2];

--- a/src/Layer/LayerFactory.C
+++ b/src/Layer/LayerFactory.C
@@ -59,6 +59,9 @@
 #include "RemLayer.h"
 #include "QsLog.h"
 #include "openbabel/mol.h"
+#include "openbabel/atom.h"
+#include "openbabel/bond.h"
+#include "openbabel/obiter.h"
 
 #include <typeinfo>   // for std::bad_cast
 

--- a/src/Layer/MoleculeLayer.C
+++ b/src/Layer/MoleculeLayer.C
@@ -63,11 +63,15 @@
 #include "IQmolParser.h"
 
 #include "openbabel/mol.h"
+#include "openbabel/atom.h"
+#include "openbabel/bond.h"
+#include "openbabel/typer.h"
 #include "openbabel/format.h"
 #include "openbabel/obconversion.h"
 #include "openbabel/generic.h"
 #include "openbabel/forcefield.h"
 #include "openbabel/plugin.h"
+#include "openbabel/obiter.h"
 
 #include <QFileDialog>
 #include <QDropEvent>
@@ -516,7 +520,7 @@ OBMol* Molecule::toOBMol(AtomMap* atomMap, BondMap* bondMap, GroupMap* groupMap)
    AtomList::iterator atomIter;
 
    obMol->BeginModify();
-   obMol->SetImplicitValencePerceived();
+   //obMol->SetImplicitValencePerceived(); // FIXME: this function doesn't appear to exist in OpenBabel3?
    obMol->SetHybridizationPerceived();
 
    for (atomIter = atoms.begin(); atomIter != atoms.end(); ++atomIter) {
@@ -1803,14 +1807,14 @@ void Molecule::addHydrogens()
    // We now type the atoms and overwrite the valency/hybridization info
    // if it has been changed by the user.
    OBAtomTyper atomTyper;
-   atomTyper.AssignImplicitValence(*obMol);
+   // atomTyper.AssignImplicitValence(*obMol); // FIXME: this function doesn't appear to exist in OpenBabel3?
    atomTyper.AssignHyb(*obMol);
 
    AtomMap::iterator iter;
    for (iter = atomMap.begin(); iter != atomMap.end(); ++iter) {
        int hybrid(iter.value()->getHybridization());
        if (hybrid > 0) {
-          iter.key()->SetImplicitValence(iter.value()->getValency());
+	  // iter.key()->SetImplicitValence(iter.value()->getValency()); // FIXME: this function doesn't appear to exist in OpenBabel3?
           iter.key()->SetHyb(hybrid);
        }
    }

--- a/src/Layer/PrimitiveLayer.C
+++ b/src/Layer/PrimitiveLayer.C
@@ -25,6 +25,8 @@
 #include "Geometry.h"
 #include "openbabel/obiter.h"
 #include "openbabel/mol.h"
+#include "openbabel/atom.h"
+#include "openbabel/bond.h"
 
 #define _USE_MATH_DEFINES
 #include <cmath>

--- a/src/Main/PeriodicTable.C
+++ b/src/Main/PeriodicTable.C
@@ -51,7 +51,7 @@ void PeriodicTable::connectSignals() {
        name.remove(QRegExp("element_"));
        atomicNumber = name.toUInt(&ok);
        if (ok) {
-          name = QString(OpenBabel::etab.GetName(atomicNumber).c_str());
+          name = QString(OpenBabel::OBElements::GetName(atomicNumber));
           (*iter)->setToolTip(QString::number(atomicNumber) + " " + name);
        }
    }
@@ -75,7 +75,7 @@ void PeriodicTable::buttonPushed() {
    int atomicNumber = name.toUInt(&ok);
    if (ok) {
       elementSelected(atomicNumber);
-      elementSelected(QString(OpenBabel::etab.GetSymbol(atomicNumber)));
+      elementSelected(QString(OpenBabel::OBElements::GetSymbol(atomicNumber)));
    }
 }
 

--- a/src/Old/AtomicDensity.C
+++ b/src/Old/AtomicDensity.C
@@ -23,7 +23,7 @@
 #include "Constants.h"
 #include "AtomicDensity.h"
 #include "AtomicDensityData.h"
-#include <openbabel/mol.h>  // for OpenBabel::etab
+#include <openbabel/elements.h>
 #include <cmath>
 
 
@@ -168,7 +168,7 @@ unsigned VanDerWaals::s_indices[20][3] = {
 VanDerWaals::VanDerWaals(unsigned atomicNumber, Vec const& center, double const scale,
    double const solventRadius) : Base(atomicNumber), m_center(center)
 {
-   m_radius = scale*OpenBabel::etab.GetVdwRad(atomicNumber)+solventRadius;
+   m_radius = scale*OpenBabel::OBElements::GetVdwRad(atomicNumber)+solventRadius;
 }
 
 

--- a/src/Parser/OpenBabelParser.C
+++ b/src/Parser/OpenBabelParser.C
@@ -44,7 +44,7 @@
 #include "openbabel/forcefield.h"
 #include "openbabel/griddata.h"
 #include "openbabel/math/vector3.h"
-
+#include "openbabel/obiter.h"
 
 
 namespace IQmol {

--- a/src/Parser/ZMatrixCoordinatesParser.C
+++ b/src/Parser/ZMatrixCoordinatesParser.C
@@ -25,6 +25,8 @@
 #include "openbabel/obconversion.h"
 #include "openbabel/format.h"
 #include "openbabel/mol.h"
+#include "openbabel/obiter.h"
+#include "openbabel/atom.h"
 
 #include <QDebug>
 

--- a/src/Qui/QuiMolecule.C
+++ b/src/Qui/QuiMolecule.C
@@ -21,6 +21,9 @@
 #include "openbabel/format.h"
 #include "openbabel/obconversion.h"
 #include "openbabel/forcefield.h"
+#include "openbabel/elements.h"
+#include "openbabel/obiter.h"
+#include "openbabel/internalcoord.h"
 
 #include "QuiMolecule.h"
 
@@ -182,7 +185,7 @@ QString Molecule::formatForQui(Coordinates::ID const& coords) {
              << GetTotalCharge() << GetTotalSpinMultiplicity() << "\n";
          FOR_ATOMS_OF_MOL(atom, this) {
             mol << qSetFieldWidth(3) << right 
-                << QString(etab.GetSymbol(atom->GetAtomicNum()))
+                << QString(OBElements::GetSymbol(atom->GetAtomicNum()))
                 << qSetFieldWidth(12) << qSetRealNumberPrecision(6)
                 << fixed << right << atom->GetX() << atom->GetY() << atom->GetZ()
                 << qSetFieldWidth(0) << "\n";
@@ -209,24 +212,24 @@ QString Molecule::formatForQui(Coordinates::ID const& coords) {
          c = vic[atom->GetIdx()]->_c;
 
          mol << qSetFieldWidth(4) << right
-             << QString(etab.GetSymbol(atom->GetAtomicNum())
+             << QString(OBElements::GetSymbol(atom->GetAtomicNum())
                       + QString::number(atom->GetIdx()))
              << qSetFieldWidth(0);
  
          if (atom->GetIdx() > 1) {
-            mol << " "  << QString(etab.GetSymbol(a->GetAtomicNum())
+            mol << " "  << QString(OBElements::GetSymbol(a->GetAtomicNum())
                            + QString::number(a->GetIdx()))
                 << " r" << atom->GetIdx();
          }
 
          if (atom->GetIdx() > 2) {
-            mol << " "  << QString(etab.GetSymbol(b->GetAtomicNum())
+            mol << " "  << QString(OBElements::GetSymbol(b->GetAtomicNum())
                          + QString::number(b->GetIdx()))
                 << " a" << atom->GetIdx();
          }
 
          if (atom->GetIdx() > 3) {
-            mol << " " << QString(etab.GetSymbol(c->GetAtomicNum())
+            mol << " " << QString(OBElements::GetSymbol(c->GetAtomicNum())
                           + QString::number(c->GetIdx()))
                 << " d" << atom->GetIdx();
          }
@@ -293,26 +296,26 @@ QString Molecule::formatForQui(Coordinates::ID const& coords) {
          if (t < 0.0) t += 360.0;
 
          mol << qSetFieldWidth(4) << right
-             << QString(etab.GetSymbol(atom->GetAtomicNum())
+             << QString(OBElements::GetSymbol(atom->GetAtomicNum())
                  + QString::number(atom->GetIdx()));
 
          if (atom->GetIdx() > 1) {
             mol << qSetFieldWidth(6) << right
-                << QString(etab.GetSymbol(a->GetAtomicNum())
+                << QString(OBElements::GetSymbol(a->GetAtomicNum())
                         + QString::number(a->GetIdx())) << qSetFieldWidth(12)
                 << qSetRealNumberPrecision(5) << fixed << right << r;
          }
 
          if (atom->GetIdx() > 2) {
             mol << qSetFieldWidth(6) << right
-                << QString(etab.GetSymbol(b->GetAtomicNum())
+                << QString(OBElements::GetSymbol(b->GetAtomicNum())
                     + QString::number(b->GetIdx())) << qSetFieldWidth(12)
                 << qSetRealNumberPrecision(5) << fixed << right << w;
          }
 
          if (atom->GetIdx() > 3) {
             mol << qSetFieldWidth(6) << right
-                << QString(etab.GetSymbol(c->GetAtomicNum())
+                << QString(OBElements::GetSymbol(c->GetAtomicNum())
                     + QString::number(c->GetIdx())) << qSetFieldWidth(12)
                 << qSetRealNumberPrecision(5) << fixed << right << t;
          }

--- a/src/linux.pri
+++ b/src/linux.pri
@@ -11,7 +11,7 @@ contains(CONFIG, DEVELOP){
    LIBS        += -lboost_iostreams -lboost_serialization
    
    # OpenBabel
-   INCLUDEPATH += /usr/include/openbabel-2.0
+   INCLUDEPATH += /usr/include/openbabel3
    LIBS        += -lopenbabel
 
    # SSH2/libssl/crypto
@@ -41,7 +41,7 @@ contains(CONFIG, DISTRIB) {
    LIBS        += /usr/lib/x86_64-linux-gnu/libboost_iostreams.a
    
    # OpenBabel
-   INCLUDEPATH += /usr/include/openbabel-2.0
+   INCLUDEPATH += /usr/include/openbabel3
    LIBS        += -lopenbabel
 
    # libssl/crypto
@@ -75,7 +75,7 @@ contains(CONFIG, DEPLOY) {
    LIBS        += /usr/lib/x86_64-linux-gnu/libboost_iostreams.a
    
    # OpenBabel
-   OPENBABEL    = $(DEV)/openbabel-2.4.1
+   OPENBABEL    = $(DEV)/openbabel3
    INCLUDEPATH += $${OPENBABEL}/include
    LIBS        += $${OPENBABEL}/build/src/libopenbabel.a
 


### PR DESCRIPTION
Tentative port of IQmol to OpenBabel 3 branch.
Fixes #54 

The port consists mostly of adding missing includes, and porting the handling of elements https://open-babel.readthedocs.io/en/latest/UseTheLibrary/migration.html

The only problem is that since the implicit valence functions appear to have been removed, a few lines in MoleculeLayer need attention. @nutjunkie 